### PR TITLE
fix: auto mode and listmodels now work correctly with custom provider

### DIFF
--- a/providers/custom.py
+++ b/providers/custom.py
@@ -1,8 +1,12 @@
 """Custom API provider implementation."""
 
 import logging
+from typing import TYPE_CHECKING
 
 from utils.env import get_env
+
+if TYPE_CHECKING:
+    from tools.models import ToolModelCategory
 
 from .openai_compatible import OpenAICompatibleProvider
 from .registries.custom import CustomEndpointModelRegistry
@@ -115,6 +119,12 @@ class CustomProvider(OpenAICompatibleProvider):
         """Identify this provider for restriction and logging logic."""
 
         return ProviderType.CUSTOM
+
+    def get_preferred_model(self, category: "ToolModelCategory", allowed_models: list[str]) -> str | None:
+        """Prefer the model explicitly configured for the custom endpoint."""
+
+        custom_model = (get_env("CUSTOM_MODEL_NAME", "") or "").strip().casefold()
+        return next((model for model in allowed_models if model.casefold() == custom_model), None)
 
     # ------------------------------------------------------------------
     # Registry helpers

--- a/providers/registries/custom.py
+++ b/providers/registries/custom.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from utils.env import get_env
+
 from ..shared import ModelCapabilities, ProviderType
 from .base import CAPABILITY_FIELD_NAMES, CapabilityModelRegistry
 
@@ -17,6 +19,19 @@ class CustomEndpointModelRegistry(CapabilityModelRegistry):
             friendly_prefix="Custom ({model})",
             config_path=config_path,
         )
+
+        custom_model = (get_env("CUSTOM_MODEL_NAME", "") or "").strip()
+        if custom_model and not self.resolve(custom_model):
+            self.model_map[custom_model] = ModelCapabilities(
+                provider=ProviderType.CUSTOM,
+                model_name=custom_model,
+                friendly_name=f"Custom ({custom_model})",
+                description="Custom model configured by CUSTOM_MODEL_NAME",
+                context_window=32_768,
+                max_output_tokens=16_000,
+                intelligence_score=6,
+            )
+            self.alias_map[custom_model.lower()] = custom_model
 
     def _finalise_entry(self, entry: dict) -> tuple[ModelCapabilities, dict]:
         filtered = {k: v for k, v in entry.items() if k in CAPABILITY_FIELD_NAMES}

--- a/tests/test_auto_mode_custom_provider_only.py
+++ b/tests/test_auto_mode_custom_provider_only.py
@@ -168,10 +168,13 @@ class TestAutoModeCustomProviderOnly:
     def test_auto_mode_fallback_with_custom_only_should_work(self):
         """Test that auto mode fallback should work when only custom provider is available."""
 
+        configured_model = "zzz-configured-custom-model"
+
         # Set up environment with only custom provider
         test_env = {
             "CUSTOM_API_URL": "http://localhost:11434/v1",
             "CUSTOM_API_KEY": "",
+            "CUSTOM_MODEL_NAME": f" {configured_model} ",
             "DEFAULT_MODEL": "auto",
         }
 
@@ -189,20 +192,16 @@ class TestAutoModeCustomProviderOnly:
             # Register custom provider
             from providers.custom import CustomProvider
 
-            ModelProviderRegistry.register_provider(ProviderType.CUSTOM, CustomProvider)
+            with patch.object(CustomProvider, "_registry", None):
+                ModelProviderRegistry.register_provider(ProviderType.CUSTOM, CustomProvider)
 
-            # This should work and return a fallback model from custom provider
-            # Currently fails because get_preferred_fallback_model doesn't consider custom models
-            from tools.models import ToolModelCategory
+                from providers.registries.custom import CustomEndpointModelRegistry
+                from tools.models import ToolModelCategory
 
-            try:
-                fallback_model = ModelProviderRegistry.get_preferred_fallback_model(ToolModelCategory.FAST_RESPONSE)
-                print(f"Fallback model for FAST_RESPONSE: {fallback_model}")
-
-                # Should get a valid model name, not the hardcoded fallback
+                registry = CustomEndpointModelRegistry()
+                assert registry.resolve(configured_model) is not None
+                assert configured_model in registry.list_aliases()
                 assert (
-                    fallback_model != "gemini-2.5-flash"
-                ), "Should not fallback to hardcoded Gemini model when custom provider is available"
-
-            except Exception as e:
-                pytest.fail(f"Getting fallback model failed: {e}")
+                    ModelProviderRegistry.get_preferred_fallback_model(ToolModelCategory.FAST_RESPONSE)
+                    == configured_model
+                )


### PR DESCRIPTION
## Summary

- Make `CUSTOM_MODEL_NAME` visible to every custom model registry, including `listmodels`.
- Prefer that configured model when auto mode selects from the custom provider.

Fixes #327.
Fixes #344.

## Testing

- `python -m pytest tests/test_auto_mode_custom_provider_only.py -q` — 4 passed
- Ruff, Black, and isort checks passed for the changed files.