### PR TITLE
fix(deps): pin mcp SDK below v2 to prevent fresh install crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "9.8.2"
 description = "AI-powered MCP server with multiple model providers"
 requires-python = ">=3.9"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",
     "google-genai>=1.19.0",
     "openai>=1.55.2",
     "pydantic>=2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp>=1.0.0
+mcp>=1.0.0,<2
 google-genai>=1.19.0
 openai>=1.55.2  # Minimum version for httpx 0.28.0 compatibility
 pydantic>=2.0.0


### PR DESCRIPTION
## Summary

Pin the MCP Python SDK to `<2` so fresh installs no longer resolve `mcp` 2.x and crash at import with `AttributeError: 'Server' object has no attribute 'list_tools'`.

## Motivation

`pyproject.toml` and `requirements.txt` declared `mcp>=1.0.0` with no upper bound. MCP SDK v2.0.0 removed decorator-based handlers (`@server.list_tools()`, etc.) that `server.py` still uses. Fresh installs via `uvx` or `pip` now pull mcp 2.x and fail before the server starts (#470).

This is the interim fix recommended by the MCP SDK migration guide until the project migrates to constructor `on_*` callbacks.

## Changes

- `pyproject.toml`: `mcp>=1.0.0,<2`
- `requirements.txt`: `mcp>=1.0.0,<2`

## Tests

```bash
pip install -r requirements.txt -r requirements-dev.txt
python -m pytest tests/ -v --ignore=simulator_tests/ -m "not integration"
python -c "import server"
```

- 866 unit tests passed
- Server imports successfully with mcp 1.29.1

## Notes

- Does not migrate to MCP 2.x API; a follow-up issue/PR would be needed for full migration
- Both install paths (`pip install .` via pyproject and Docker/CI via requirements.txt) are covered

Fixes #470